### PR TITLE
changes to support revision id in spec

### DIFF
--- a/drive/revision_list.go
+++ b/drive/revision_list.go
@@ -19,7 +19,8 @@ type ListRevisionsArgs struct {
 }
 
 func (g *Drive) ListRevisions(args ListRevisionsArgs) error {
-	revList, err := g.service.Revisions.List(args.Id).Fields("revisions(id,keepForever,size,modifiedTime,originalFilename)").Do()
+	revList, err := g.service.Revisions.List(args.Id).
+		Fields("revisions(id,keepForever,size,modifiedTime,originalFilename,md5Checksum)").Do()
 	if err != nil {
 		return fmt.Errorf("failed listing revisions: %s", err)
 	}

--- a/reconciler/const.go
+++ b/reconciler/const.go
@@ -3,5 +3,6 @@ package reconciler
 const (
 	SpecKind              = "diamanti.com/reconcile"
 	SpecApiVersionV1Beta1 = "v1Beta1"
+	SpecApiVersionV1Beta2 = "v1Beta2"
 	StandardCache         = "var/gdrive-cache"
 )

--- a/reconciler/file.go
+++ b/reconciler/file.go
@@ -140,22 +140,40 @@ func (f *File) download() error {
 	bb := new(bytes.Buffer)
 	bw := bufio.NewWriter(bb)
 
-	args := drive.DownloadArgs{
-		Out:       bw,
-		Progress:  os.Stderr,
-		Id:        f.Id,
-		Path:      tmpFolder,
-		Force:     true,
-		Skip:      false,
-		Recursive: false,
-		Delete:    false,
-		Stdout:    false,
-		Timeout:   time.Second * 120,
-		JsonOut:   true,
-	}
+	if len(f.RevId) == 0 {
+		args := drive.DownloadArgs{
+			Out:       bw,
+			Progress:  os.Stderr,
+			Id:        f.Id,
+			Path:      tmpFolder,
+			Force:     true,
+			Skip:      false,
+			Recursive: false,
+			Delete:    false,
+			Stdout:    false,
+			Timeout:   time.Second * 120,
+			JsonOut:   true,
+		}
 
-	if err := f.g.Download(args); err != nil {
-		return err
+		if err := f.g.Download(args); err != nil {
+			return err
+		}
+	} else {
+		args := drive.DownloadRevisionArgs{
+			Out:        bw,
+			Progress:   os.Stderr,
+			FileId:     f.Id,
+			RevisionId: f.RevId,
+			Path:       tmpFolder,
+			Force:      true,
+			Stdout:     false,
+			Timeout:    time.Second * 120,
+			JsonOut:    true,
+		}
+
+		if err := f.g.DownloadRevision(args); err != nil {
+			return err
+		}
 	}
 
 	_ = bw.Flush()

--- a/reconciler/new.go
+++ b/reconciler/new.go
@@ -29,13 +29,14 @@ func New(fileName string, g *drive.Drive) (Reconciler, error) {
 	}
 
 	switch v := k.ApiVersion; v {
-	case SpecApiVersionV1Beta1:
+	case SpecApiVersionV1Beta1, SpecApiVersionV1Beta2:
 	default:
-		return nil, fmt.Errorf("spec api version is not valid. expected:%s", SpecApiVersionV1Beta1)
+		return nil, fmt.Errorf("spec api version is not valid. expected:%s or %s",
+			SpecApiVersionV1Beta1, SpecApiVersionV1Beta2)
 	}
 
 	switch v := k.ApiVersion; v {
-	case SpecApiVersionV1Beta1:
+	case SpecApiVersionV1Beta1, SpecApiVersionV1Beta2:
 		spec := new(Spec)
 		if err := yaml.Unmarshal(b, spec); err != nil {
 			return nil, err

--- a/reconciler/types.go
+++ b/reconciler/types.go
@@ -28,6 +28,8 @@ type File struct {
 	LocalPath string
 	// Id of file in gdrive
 	Id string
+	// RevId is revision ID of file
+	RevId string
 	// Md5 checksum of file used to reconcile states
 	Md5 string
 	// remoteName is the name of the file on gdrive


### PR DESCRIPTION
a new field called revid got added to the reconciler spec that
allows referencing specific revision id for a file.

both spec gen and spec apply will now produce and consume
rev id based specs

Signed-off-by: Saurabh Deoras <saurabh@diamanti.com>

 Please enter the commit message for your changes. Lines starting
 with '' will be ignored, and an empty message aborts the commit.

 On branch v1beta2
 Changes to be committed:
	modified:   drive/revision_list.go
	modified:   reconciler/const.go
	modified:   reconciler/file.go
	modified:   reconciler/new.go
	modified:   reconciler/spec.go
	modified:   reconciler/types.go